### PR TITLE
Fixed multiline text serialization, added support for font-weight and font-style

### DIFF
--- a/raphael.export.js
+++ b/raphael.export.js
@@ -15,7 +15,7 @@
 	function escapeXML(s) {
 		if ( typeof s === 'number' ) return s.toString();
 
-		var replace = { '&': 'amp', '<': 'lt', '>': 'gt', '"': 'quot', '\'': 'apos' };
+		var replace = { '<': 'lt', '>': 'gt', '"': 'quot', '\'': 'apos' };
 
 		for ( var entity in replace ) {
 			s = s.replace(new RegExp(entity, 'g'), '&' + replace[entity] + ';');


### PR DESCRIPTION
The mapped callback in the serializer for 'text' had mismatched arguments, so the line index wasn't getting passed through.

Also, I beefed-up the support for detecting font styles within text tags.

Thanks for this library!
