### PR TITLE
Update raphael.export.js

### DIFF
--- a/raphael.export.js
+++ b/raphael.export.js
@@ -181,7 +181,7 @@
 						{ style: styleToString(style) + ';' }
 						),
 					node.matrix,
-					tag('tspan', { dy: computeTSpanDy(style.font.size, line + 1, totalLines) }, null, text)
+					tag('tspan', { dy: computeTSpanDy(style.font.size, line + 1, totalLines) }, null, text.replace(/&/g, "&amp;"))
 				));
 			});
 


### PR DESCRIPTION
svg gets broken if '&' is in text because it doesnt escape
