### PR TITLE
Fixing Undefined error in font-family attr in extractStyle function

### DIFF
--- a/raphael.export.js
+++ b/raphael.export.js
@@ -115,7 +115,7 @@
 	function extractStyle(node) {
 		return {
 			font: {
-				family: node.attrs.font.replace(/^.*?"(\w+)".*$/, '$1'),
+				family: typeof node.attrs.font === 'undefined' ? null : node.attrs.font.replace(/^.?"(\w+)".$/, '$1'),				
 				size:   typeof node.attrs['font-size'] === 'undefined' ? null : parseInt( node.attrs['font-size'] ),
 				style: typeof node.attrs['font-style'] === 'undefined' ? null : node.attrs['font-style'],
 				weight: typeof node.attrs['font-weight'] === 'undefined' ? null : node.attrs['font-weight']


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'replace' of undefined in the
extractStyle function (font-family attribute). If I don't have this
attribute in my image then error is thrown. The line 118 must be
replaced by : family: typeof node.attrs.font === 'undefined' ? null :
node.attrs.font.replace(/^.?"(\w+)".$/, '$1'),