### PR TITLE
A fix for some errors in escapeXML()

### DIFF
--- a/raphael.export.js
+++ b/raphael.export.js
@@ -20,7 +20,7 @@
 		// couldn't be converted to a string.  In this case, a JavaScript error
 		// will be thrown, and our catch block will return an empty string.
 		try {
-			var replace = { '<': 'lt', '>': 'gt', '"': 'quot', '\'': 'apos' };
+			var replace = { '&': 'amp', '<': 'lt', '>': 'gt', '"': 'quot', '\'': 'apos' };
 
 			// Ensure s is a string, by converting it using toString(), if possible.
 			// If this method doesn't exist, then an error will be thrown and our

--- a/raphael.export.js
+++ b/raphael.export.js
@@ -15,13 +15,29 @@
 	function escapeXML(s) {
 		if ( typeof s === 'number' ) return s.toString();
 
-		var replace = { '<': 'lt', '>': 'gt', '"': 'quot', '\'': 'apos' };
+		// We wrap the check in a try/catch block.  If an error occurs then the
+		// function was passed a non-string value or a value that otherwise
+		// couldn't be converted to a string.  In this case, a JavaScript error
+		// will be thrown, and our catch block will return an empty string.
+		try {
+			var replace = { '<': 'lt', '>': 'gt', '"': 'quot', '\'': 'apos' };
 
-		for ( var entity in replace ) {
-			s = s.replace(new RegExp(entity, 'g'), '&' + replace[entity] + ';');
+			// Ensure s is a string, by converting it using toString(), if possible.
+			// If this method doesn't exist, then an error will be thrown and our
+			// catch block will return an empty string.
+			// Note that (perhaps, surprisingly) string values have a toString()
+			// function, so we don't need to check the type before calling.
+			s = s.toString();
+
+			for ( var entity in replace ) {
+				s = s.replace(new RegExp(entity, 'g'), '&' + replace[entity] + ';');
+			}
+
+			return s;
+
+		} catch ( e ) {
+			return "";
 		}
-
-		return s;
 	}
 
 	/**


### PR DESCRIPTION
Fixed an issue in escapeXML() whereby if the supplied value is undefined, a JavaScript error was thrown.

I have implemented this fix in a generic fashion, i.e. it will now behave correctly for any non-string value that doesn't implement a toString() method (not just undefined values).  If toString() is available, then this will be used to convert the value to a string prior to performing the necessary replacements, otherwise we catch the resulting JavaScript error and return an empty string.

This works around an IE8 issue, whereby node.node.className.baseVal is not defined, resulting in a 'class' attribute set to undefined.  I have logged the underlying issue as issue #53, but this fix means that we should no longer generate a JavaScript error when this situation occurs.